### PR TITLE
Included name of Youtube Video in CLI after downloaded is finished

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,14 @@ __pycache__/
 .venv
 env/
 venv/
+Pipfile
+Pipfile.lock
 
 # Download folder
 downloads/
+
+# Json debug folder
+.vscode/
 
 # Configuration
 .idea/

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,5 +3,5 @@
 [timotheeMM](https://github.com/timotheemm)
 
 # Contributors
-
+[Alec Smith] (https://github.com/sharktankful)
 > Add your name here if you contributed to this project

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,6 @@
 from pytube import YouTube
 from tqdm import tqdm
 
-
 def cli():
     """
     Command Line Interface for downloading YouTube videos.
@@ -17,9 +16,12 @@ def cli():
 
         try:
             yt = YouTube(url)
+            video_title = yt.title
 
         except:
             exit("\nThe URL you provided is either empty or invalid.")
+
+
 
         stream = yt.streams.get_highest_resolution()
         pbar = tqdm(total=stream.filesize, unit="B", unit_scale=True, colour="red")
@@ -40,7 +42,7 @@ def cli():
         stream.download("downloads/")
 
         pbar.close()
-        print("Download successfully completed!\n")
+        print(f"Download successfully completed!\nDOWNLOADED: {video_title}\n")
 
     video_url = input("\nEnter the URL of the YouTube video: ")
     download_video(video_url)


### PR DESCRIPTION
I've included the name of the downloaded video title in the CLI after the download has finished. That way the user can make sure the video they downloaded is correct without checking the folder the videos in.